### PR TITLE
refactor: make Rosetta server base URL explicit, removing Lunar default

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,8 @@ import { RosettaClient } from '@lunarhq/rosetta-ts-client';
 
 /**
  * Initialize Client
- * RosettaClient params are optional
  */ 
-const baseUrl = 'https://api.lunar.dev/v1/';
+const baseUrl = 'https://api.lunar.dev/v1';
 const headers = {
   'X-Api-Key': 'XXXXXXXXXX'
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -3,7 +3,7 @@ import * as rosetta from "./types/rosetta";
 import * as utils from "./utils";
 
 interface RosettaClientParams {
-  baseUrl?: string;
+  baseUrl: string;
   headers?: {
     [key: string]: string;
   };
@@ -13,8 +13,8 @@ export class RosettaClient {
   _baseUrl: string;
   _headers: { [key: string]: string };
 
-  constructor(params?: RosettaClientParams) {
-    this._baseUrl = params?.baseUrl ?? "https://api.lunar.dev/v1";
+  constructor(params: RosettaClientParams) {
+    this._baseUrl = params?.baseUrl;
     this._headers = params?.headers ?? {};
   }
 


### PR DESCRIPTION
Closes #8

BREAKING CHANGE: `RosettaClientParams.baseUrl` is now a required property.

~Couple of points to note:~ EDIT: Kashif reached out over email to notify of an outage.
~1. The docs suggest you can query test networks at https://api.lunar.dev/v1 without an API key, however I'm getting `401`s.~
~2. I was unable to generate an API key from an account at https://lunar.dev~